### PR TITLE
[revshare] support storing multiple revshare configs in one plugin

### DIFF
--- a/metagov/metagov/core/views.py
+++ b/metagov/metagov/core/views.py
@@ -390,7 +390,7 @@ def decorated_perform_action_view(plugin_name, slug, tags=[]):
         parameters = {}
         if request.method == "POST" and request.body:
             payload = JSONParser().parse(request)
-            parameters = payload.get("parameters")
+            parameters = payload.get("parameters", {})
             # TODO: add back support for GET. Should be allowed if params are simple enough.
         if request.method == "GET":
             parameters = request.GET.dict()  # doesnt support repeated params 'a=2&a=3'

--- a/metagov/metagov/plugins/revshare/models.py
+++ b/metagov/metagov/plugins/revshare/models.py
@@ -31,7 +31,7 @@ class RevShare(Plugin):
         pointer = parameters["pointer"]
         weight = parameters["weight"]
         key = parameters.get("key", DEFAULT_KEY)
-        config = self.state.get(key, {})
+        config = self.state.get(key) or {}
         config[pointer] = weight
         self.state.set(key, config)
         return config
@@ -44,7 +44,7 @@ class RevShare(Plugin):
     def remove_pointer(self, parameters):
         pointer = parameters["pointer"]
         key = parameters.get("key", DEFAULT_KEY)
-        config = self.state.get(key, {})
+        config = self.state.get(key) or {}
         config.pop(pointer, None)
         self.state.set(key, config)
         return config
@@ -68,7 +68,7 @@ class RevShare(Plugin):
     )
     def get_config(self, parameters):
         key = parameters.get("key", DEFAULT_KEY)
-        return self.state.get(key, {})
+        return self.state.get(key) or {}
 
     @Registry.action(
         slug="pick-pointer",
@@ -79,7 +79,7 @@ class RevShare(Plugin):
     )
     def pick_pointer(self, parameters):
         key = parameters.get("key", DEFAULT_KEY)
-        pointers = self.state.get(key, {})
+        pointers = self.state.get(key) or {}
         if len(pointers) == 0:
             raise PluginErrorInternal(f"No pointers for key {key}")
         # based on https://webmonetization.org/docs/probabilistic-rev-sharing/

--- a/metagov/metagov/plugins/revshare/models.py
+++ b/metagov/metagov/plugins/revshare/models.py
@@ -1,13 +1,14 @@
-import json
 import logging
 import random
 
 import metagov.core.plugin_decorators as Registry
 import metagov.plugins.revshare.schemas as Schemas
+from metagov.core.errors import PluginErrorInternal
 from metagov.core.models import Plugin
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_KEY = "_DEFAULT"
 
 @Registry.plugin
 class RevShare(Plugin):
@@ -19,60 +20,68 @@ class RevShare(Plugin):
     def initialize(self):
         # This state only lasts as long as the plugin does.
         # If the community decides to de-activates the plugin, the plugin instance is deleted and the state is lost.
-        self.state.set("pointers", {})
+        self.state.set(DEFAULT_KEY, {})
 
     @Registry.action(
         slug="add-pointer",
         description="Add weighted pointer to revshare config, or update its weight if it already exists",
-        input_schema=Schemas.pointer_and_weight,
+        input_schema=Schemas.add_pointer_input,
     )
     def add_pointer(self, parameters):
         pointer = parameters["pointer"]
         weight = parameters["weight"]
-
-        config = self.state.get("pointers")
+        key = parameters.get("key", DEFAULT_KEY)
+        config = self.state.get(key, {})
         config[pointer] = weight
-        self.state.set("pointers", config)
+        self.state.set(key, config)
         return config
 
     @Registry.action(
-        slug="remove-pointer", description="Remove pointer from revshare config", input_schema=Schemas.pointer
+        slug="remove-pointer",
+        description="Remove pointer from revshare config",
+        input_schema=Schemas.remove_pointer_input
     )
     def remove_pointer(self, parameters):
         pointer = parameters["pointer"]
-        config = self.state.get("pointers")
+        key = parameters.get("key", DEFAULT_KEY)
+        config = self.state.get(key, {})
         config.pop(pointer, None)
-        self.state.set("pointers", config)
+        self.state.set(key, config)
         return config
 
     @Registry.action(
         slug="replace-config",
         description="Replace revshare config with new config",
-        input_schema=Schemas.pointers,
+        input_schema=Schemas.replace_config_input,
     )
     def replace(self, parameters):
         new_pointers = parameters["pointers"]
-        self.state.set("pointers", new_pointers)
+        key = parameters.get("key", DEFAULT_KEY)
+        self.state.set(key, new_pointers)
         return new_pointers
 
     @Registry.action(
         slug="get-config",
         description="Get current revshare configuration",
+        input_schema=Schemas.get_config_input,
         is_public=True,
     )
     def get_config(self, parameters):
-        return self.state.get("pointers")
+        key = parameters.get("key", DEFAULT_KEY)
+        return self.state.get(key, {})
 
     @Registry.action(
         slug="pick-pointer",
         description="Choose a random pointer according to weights",
-        output_schema=Schemas.pointer,
+        input_schema=Schemas.pick_pointer_input,
+        output_schema=Schemas.pick_pointer_output,
         is_public=True,
     )
     def pick_pointer(self, parameters):
-        pointers = self.state.get("pointers")
+        key = parameters.get("key", DEFAULT_KEY)
+        pointers = self.state.get(key, {})
         if len(pointers) == 0:
-            raise Exception("No pointers")
+            raise PluginErrorInternal(f"No pointers for key {key}")
         # based on https://webmonetization.org/docs/probabilistic-rev-sharing/
         sum_ = sum(list(pointers.values()))
         choice = random.random() * sum_

--- a/metagov/metagov/plugins/revshare/schemas.py
+++ b/metagov/metagov/plugins/revshare/schemas.py
@@ -1,27 +1,32 @@
-pointer_and_weight = {
+add_pointer_input = {
     "type": "object",
     "additionalProperties": False,
-    "properties": {"pointer": {"type": "string"}, "weight": {"type": "integer"}},
+    "properties": {"pointer": {"type": "string"}, "weight": {"type": "integer"}, "key": {"type": "string"}},
     "required": ["pointer", "weight"],
 }
-pointer = {
+remove_pointer_input = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"pointer": {"type": "string"}, "key": {"type": "string"}},
+    "required": ["pointer"],
+}
+replace_config_input = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"pointers": {"type": "object"}, "key": {"type": "string"}},
+    "required": ["pointers"],
+}
+get_config_input = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"key": {"type": "string"}}
+}
+
+pick_pointer_input = get_config_input
+
+pick_pointer_output = {
     "type": "object",
     "additionalProperties": False,
     "properties": {"pointer": {"type": "string"}},
     "required": ["pointer"],
 }
-
-pointers = {
-    "type": "object",
-    "additionalProperties": False,
-    "properties": {"pointers": {"type": "object"}},
-    "required": ["pointers"],
-}
-
-lock_post_parameters = {
-    "type": "object",
-    "additionalProperties": False,
-    "properties": {"id": {"type": "integer"}, "locked": {"type": "boolean"}},
-    "required": ["id", "locked"],
-}
-lock_post_response = {"type": "object", "additionalProperties": False, "properties": {"locked": {"type": "boolean"}}}

--- a/metagov/metagov/plugins/revshare/tests/test_revshare.py
+++ b/metagov/metagov/plugins/revshare/tests/test_revshare.py
@@ -1,5 +1,4 @@
 from django.test import Client, TestCase
-from metagov.core.models import Community, Plugin
 from metagov.plugins.revshare.models import RevShare
 
 
@@ -20,6 +19,7 @@ class ApiTests(TestCase):
         self.client.put(self.community_url, data=self.community_data, content_type="application/json")
 
     def test_revshare(self):
+        """Test adding, removing, and requesting pointer from default key"""
         self.assertEqual(RevShare.objects.all().count(), 1)
 
         # add a pointer
@@ -37,3 +37,70 @@ class ApiTests(TestCase):
             "/api/action/revshare.pick-pointer", content_type="application/json", **self.headers
         )
         self.assertContains(response, "$alice.example")
+
+        # remove a pointer
+        parameters = {"pointer": "$alice.example"}
+        response = self.client.post(
+            "/api/internal/action/revshare.remove-pointer",
+            data={"parameters": parameters},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertNotContains(response, "$alice.example")
+
+    def test_revshare(self):
+        """Test adding, removing, and requesting pointer using different keys"""
+        self.assertEqual(RevShare.objects.all().count(), 1)
+
+        key1 = "GROUP_1"
+        key2 = "GROUP_2"
+
+        # add a pointer to group 1
+        parameters = {"pointer": "$alice.example", "weight": 1, "key": key1}
+        response = self.client.post(
+            "/api/internal/action/revshare.add-pointer",
+            data={"parameters": parameters},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertContains(response, "$alice.example")
+
+        # add a pointer to group 2
+        parameters = {"pointer": "$bob.example", "weight": 1, "key": key2}
+        response = self.client.post(
+            "/api/internal/action/revshare.add-pointer",
+            data={"parameters": parameters},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertContains(response, "$bob.example")
+        self.assertNotContains(response, "$alice.example")
+
+        # request a pointer from group 2
+        response = self.client.post(
+            "/api/action/revshare.pick-pointer",
+            data={"parameters": {"key": key2}},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertContains(response, "$bob.example")
+
+        # remove a pointer from group 2
+        parameters = {"pointer": "$bob.example", "key": key2}
+        response = self.client.post(
+            "/api/internal/action/revshare.remove-pointer",
+            data={"parameters": parameters},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertNotContains(response, "$bob.example")
+
+        # get config for group 2 (should be empty now)
+        parameters = {"key": key2}
+        response = self.client.post(
+            "/api/internal/action/revshare.get-config",
+            data={"parameters": parameters},
+            content_type="application/json",
+            **self.headers,
+        )
+        self.assertContains(response, "{}")

--- a/metagov/metagov/plugins/revshare/tests/test_revshare.py
+++ b/metagov/metagov/plugins/revshare/tests/test_revshare.py
@@ -38,6 +38,12 @@ class ApiTests(TestCase):
         )
         self.assertContains(response, "$alice.example")
 
+        # get config
+        response = self.client.post(
+            "/api/action/revshare.get-config", content_type="application/json", **self.headers
+        )
+        self.assertContains(response, "$alice.example")
+
         # remove a pointer
         parameters = {"pointer": "$alice.example"}
         response = self.client.post(


### PR DESCRIPTION
Add a `key` parameter to revshare operations to support multiple configs for one community. For example a community might have a rev share config for the "dev_core_team" and a separate one for the "content_moderators" that are used differently on the revenue-generating platform.

This change is backwards-compatible with last version of revshare plugin.

Note: another way to accomplish this would have been to support multiple Plugin instances for a community: https://github.com/metagov/metagov-prototype/issues/50