### PR TITLE
[discourse] support responding to existing DMs

### DIFF
--- a/metagov/metagov/plugins/discourse/models.py
+++ b/metagov/metagov/plugins/discourse/models.py
@@ -78,7 +78,10 @@ class Discourse(Plugin):
     def create_message(self, parameters):
         username = parameters.pop("initiator", "system")
         parameters["target_recipients"] = ",".join(parameters.pop("target_usernames"))
-        parameters["archetype"] = "private_message"
+        if parameters.get("topic_id"):
+            parameters["archetype"] = "regular"
+        else:
+            parameters["archetype"] = "private_message"
         post = self.discourse_request("POST", "posts.json", username=username, json=parameters)
         return self.construct_post_response(post)
 

--- a/metagov/metagov/plugins/discourse/schemas.py
+++ b/metagov/metagov/plugins/discourse/schemas.py
@@ -4,10 +4,11 @@ send_message_parameters = {
         "title": {"type": "string"},
         "raw": {"type": "string"},
         "is_warning": {"type": "boolean"},
+        "topic_id": {"type": "integer"},
         "target_usernames": {"type": "array", "items": {"type": "string"}},
         "initiator": {"type": "string"},
     },
-    "required": ["title", "raw", "target_usernames"],
+    "required": ["raw", "target_usernames"],
 }
 create_post_parameters = {
     "type": "object",


### PR DESCRIPTION
Example PolicyKit policy that starts a Discourse DM and responds to it later:


```
params = {
    "title": "Your new payment pointer is under review",
    "raw": f"Vote on whether to add your payment pointer to the revshare: {poll_url}",
    "target_usernames": [user]
}
response = metagov.perform_action("discourse.create-message", params)
action.data.set("dm_topic_id", response["topic_id"])
```
later:
```
params = {
    "raw": f"Your new payment pointer was added to the revshare config $$$! Current config is {response}",
    "target_usernames": [user],
     "topic_id": action.data.get("dm_topic_id")
}
metagov.perform_action("discourse.create-message", params)
```