### PR TITLE
Comment out vars from .env.example

### DIFF
--- a/metagov/metagov/.env.example
+++ b/metagov/metagov/.env.example
@@ -1,5 +1,5 @@
-DJANGO_SECRET_KEY=your-secret-key
-DATABASE_PATH=/var/databases/metagov/db.sqlite3
+# DJANGO_SECRET_KEY=your-secret-key
+# DATABASE_PATH=/var/databases/metagov/db.sqlite3
 DEBUG=True
 ALLOWED_HOSTS=127.0.0.1,.ngrok.io
-LOG_FILE=/var/log/django/metagov.log
+# LOG_FILE=/var/log/django/metagov.log


### PR DESCRIPTION
For local dev setup, we don't need the db path or log file. Comment them out so initial dev setup is more straightforward.