### PR TITLE
Remove bad import in celery task file

### DIFF
--- a/metagov/metagov/core/tasks.py
+++ b/metagov/metagov/core/tasks.py
@@ -4,7 +4,6 @@ import traceback
 from celery import shared_task
 from metagov.core.models import ProcessStatus
 from metagov.core.plugin_decorators import plugin_registry
-from metagov.core.views import get_proxy
 
 logger = logging.getLogger(__name__)
 

--- a/metagov/metagov/plugins/discourse/tests/test_discourse.py
+++ b/metagov/metagov/plugins/discourse/tests/test_discourse.py
@@ -1,9 +1,9 @@
+import metagov.plugins.discourse.tests.mocks as DiscourseMock
+import requests
+import requests_mock
+from metagov.core.tasks import execute_plugin_tasks
 from metagov.plugins.discourse.models import Discourse, DiscoursePoll
 from metagov.tests.plugin_test_utils import PluginTestCase
-
-import metagov.plugins.discourse.tests.mocks as DiscourseMock
-import requests_mock
-import requests
 
 mock_server_url = "https://discourse.metagov.org"
 discourse_process_url = "/api/internal/process/discourse.poll"
@@ -73,8 +73,8 @@ class ApiTests(PluginTestCase):
             # change mock to include some votes
             m.get(f"{mock_server_url}/posts/1.json", json=DiscourseMock.post_with_open_poll_and_votes)
 
-            # call "update" (in prod, would be invoked from celery task)
-            process.update()
+            # call celery task function, which should invoke process.update()
+            execute_plugin_tasks()
 
             # status should still be pending
             response = self.client.get(location, content_type="application/json")
@@ -94,8 +94,8 @@ class ApiTests(PluginTestCase):
             # change mock to be closed
             m.get(f"{mock_server_url}/posts/1.json", json=DiscourseMock.post_with_closed_poll_and_votes)
 
-            # call "update" (in prod, would be invoked from celery task)
-            process.update()
+            # call celery task function, which should invoke process.update()
+            execute_plugin_tasks()
 
             # status should be completed
             response = self.client.get(location, content_type="application/json")


### PR DESCRIPTION
The `tasks.py` file was importing a function that no longer exists. Fix the error, and update a test so that we would've caught this on CI.