### PR TITLE
Hz/total sourcecred cred value

### DIFF
--- a/metagov/metagov/plugins/sourcecred/models.py
+++ b/metagov/metagov/plugins/sourcecred/models.py
@@ -48,7 +48,7 @@ class SourceCred(Plugin):
         output_schema={"type": "object", "properties": {"value": {"type": "number"}}},
         is_public=True,
     )
-    def fetch_total_cred(self):
+    def fetch_total_cred(self, parameters):
         cred_data = self.fetch_accounts_analysis()
         total = 0
         for account in cred_data["accounts"]:

--- a/metagov/metagov/plugins/sourcecred/models.py
+++ b/metagov/metagov/plugins/sourcecred/models.py
@@ -42,6 +42,19 @@ class SourceCred(Plugin):
         cred = self.get_user_cred(username)
         return {"value": cred}
 
+    @Registry.action(
+        slug="total-cred",
+        description="Get total cred for the community",
+        output_schema={"type": "object", "properties": {"value": {"type": "number"}}},
+        is_public=True,
+    )
+    def fetch_total_cred(self):
+        cred_data = self.fetch_accounts_analysis()
+        total = 0
+        for account in cred_data["accounts"]:
+            total += account["totalCred"]
+        return total
+
     def get_user_cred(self, username):
         cred_data = self.fetch_accounts_analysis()
         for account in cred_data["accounts"]:

--- a/metagov/metagov/plugins/sourcecred/models.py
+++ b/metagov/metagov/plugins/sourcecred/models.py
@@ -53,7 +53,7 @@ class SourceCred(Plugin):
         total = 0
         for account in cred_data["accounts"]:
             total += account["totalCred"]
-        return total
+        return {"value": total}
 
     def get_user_cred(self, username):
         cred_data = self.fetch_accounts_analysis()


### PR DESCRIPTION
At this time metagov can access the cred score of a certain user to set a limit on what a user with a certain amount of cred can do, I think with total cred value or something that might represent reputation interesting things can happen where people would stake their reputation on some decision