### PR TITLE
Ability to get user cred with specific account id

### DIFF
--- a/metagov/metagov/plugins/sourcecred/models.py
+++ b/metagov/metagov/plugins/sourcecred/models.py
@@ -43,8 +43,8 @@ class SourceCred(Plugin):
         is_public=True,
     )
     def get_cred(self, parameters):
-        username = parameters["username"]
-        id = parameters["id"]
+        username = parameters.get('username')
+        id = parameters.get('id')
         cred = self.get_user_cred(username=username, id=id)
         return {"value": cred}
 


### PR DESCRIPTION
Account aliases is how sourcecred stores internal ids of accounts for
all platforms, storing the id in a format like this 
"N\u0000sourcecred\u0000discord\u0000MEMBER\u0000user\u0000140750062325202944\u0000"
the discord id for example is store in the index before last always
the same could apply to discourse, github, and whatever 