### PR TITLE
Support handling community creation for installs

### DIFF
--- a/metagov/metagov/core/models.py
+++ b/metagov/metagov/core/models.py
@@ -27,7 +27,7 @@ class Community(models.Model):
     def __str__(self):
         if self.readable_name:
             return f"{self.readable_name} ({self.slug})"
-        return self.slug
+        return str(self.slug)
 
 
 class DataStore(models.Model):

--- a/metagov/metagov/core/openapi_schemas.py
+++ b/metagov/metagov/core/openapi_schemas.py
@@ -123,7 +123,7 @@ plugin_authorize = {
             openapi.IN_QUERY,
             required=False,
             type=openapi.TYPE_STRING,
-            description="Unique slug for an existing community",
+            description="Slug for an existing community. If not provided, a new community will be created.",
         ),
         openapi.Parameter(
             "redirect_uri",

--- a/metagov/metagov/core/openapi_schemas.py
+++ b/metagov/metagov/core/openapi_schemas.py
@@ -1,6 +1,6 @@
 from drf_yasg import openapi
 from metagov.core.middleware import COMMUNITY_HEADER
-
+from metagov.core.plugin_constants import AuthorizationType
 
 class Tags(object):
     GOVERNANCE_PROCESS = "Governance Processes"
@@ -116,14 +116,7 @@ plugin_authorize = {
             openapi.IN_PATH,
             required=True,
             type=openapi.TYPE_STRING,
-            description="The plugin to authorize",
-        ),
-        openapi.Parameter(
-            "community",
-            openapi.IN_QUERY,
-            required=False,
-            type=openapi.TYPE_STRING,
-            description="Slug for an existing community. If not provided, a new community will be created.",
+            description="The plugin to authorize.",
         ),
         openapi.Parameter(
             "redirect_uri",
@@ -131,6 +124,22 @@ plugin_authorize = {
             required=True,
             type=openapi.TYPE_STRING,
             description="Where to redirect to after the oauth flow has completed",
+        ),
+        openapi.Parameter(
+            "community",
+            openapi.IN_QUERY,
+            required=False,
+            type=openapi.TYPE_STRING,
+            description="Slug for an existing community to install the plugin to. If not provided, a new community will be created. If type is 'user', this parameter is ignored.",
+        ),
+        openapi.Parameter(
+            "type",
+            openapi.IN_QUERY,
+            required=False,
+            type=openapi.TYPE_STRING,
+            enum=[AuthorizationType.APP_INSTALL, AuthorizationType.USER_LOGIN],
+            default=AuthorizationType.APP_INSTALL,
+            description="Whether to authorize an app install (which will enable a plugin), or to authorize a user login. Defaults to app install.",
         ),
     ],
 }

--- a/metagov/metagov/core/openapi_schemas.py
+++ b/metagov/metagov/core/openapi_schemas.py
@@ -121,7 +121,7 @@ plugin_authorize = {
         openapi.Parameter(
             "community",
             openapi.IN_QUERY,
-            required=True,
+            required=False,
             type=openapi.TYPE_STRING,
             description="Unique slug for an existing community",
         ),

--- a/metagov/metagov/core/plugin_constants.py
+++ b/metagov/metagov/core/plugin_constants.py
@@ -1,3 +1,3 @@
-class AuthType:
+class AuthorizationType:
     USER_LOGIN = "user"
     APP_INSTALL = "app"

--- a/metagov/metagov/core/views.py
+++ b/metagov/metagov/core/views.py
@@ -17,7 +17,7 @@ from metagov.core.errors import PluginAuthError
 from metagov.core.middleware import CommunityMiddleware
 from metagov.core.models import Community, Plugin, ProcessStatus
 from metagov.core.openapi_schemas import Tags
-from metagov.core.plugin_constants import AuthType
+from metagov.core.plugin_constants import AuthorizationType
 from metagov.core.plugin_decorators import plugin_registry
 from metagov.core.serializers import CommunitySerializer, GovernanceProcessSerializer, PluginSerializer
 from requests.models import PreparedRequest
@@ -175,7 +175,7 @@ def plugin_authorize(request, plugin_name):
         return HttpResponseBadRequest(f"No such plugin: {plugin_name}")
 
     # auth type (user login or app installation)
-    type = request.GET.get("type")
+    type = request.GET.get("type", AuthorizationType.APP_INSTALL)
     # community to install to (optional for installation, ignored for user login)
     community_slug = request.GET.get("community")
     # where to redirect after auth flow is done
@@ -184,11 +184,11 @@ def plugin_authorize(request, plugin_name):
     received_state = request.GET.get("state")
     request.session["received_authorize_state"] = received_state
 
-    if type != AuthType.APP_INSTALL and type != AuthType.USER_LOGIN:
-        return HttpResponseBadRequest(f"Parameter 'type' must be '{AuthType.APP_INSTALL}' or '{AuthType.USER_LOGIN}'")
+    if type != AuthorizationType.APP_INSTALL and type != AuthorizationType.USER_LOGIN:
+        return HttpResponseBadRequest(f"Parameter 'type' must be '{AuthorizationType.APP_INSTALL}' or '{AuthorizationType.USER_LOGIN}'")
 
     community = None
-    if type == AuthType.APP_INSTALL:
+    if type == AuthorizationType.APP_INSTALL:
         if community_slug:
             try:
                 community = Community.objects.get(slug=community_slug)
@@ -213,9 +213,9 @@ def plugin_authorize(request, plugin_name):
 
     url = plugin_views.get_authorize_url(state_encoded, type, community)
 
-    if type == AuthType.APP_INSTALL:
+    if type == AuthorizationType.APP_INSTALL:
         logger.info(f"Redirecting to authorize '{plugin_name}' for community {community}")
-    elif type == AuthType.USER_LOGIN:
+    elif type == AuthorizationType.USER_LOGIN:
         logger.info(f"Redirecting to authorize user for '{plugin_name}'")
     return HttpResponseRedirect(url)
 
@@ -261,7 +261,7 @@ def plugin_auth_callback(request, plugin_name):
         return redirect_with_params(redirect_uri, {"state": state_to_pass, "error": "server_error"})
 
     community = None
-    if type == AuthType.APP_INSTALL:
+    if type == AuthorizationType.APP_INSTALL:
         # For installs, validate the community
         if not community_slug:
             return redirect_with_params(redirect_uri, {"state": state_to_pass, "error": "bad_state"})

--- a/metagov/metagov/core/views.py
+++ b/metagov/metagov/core/views.py
@@ -188,6 +188,7 @@ def plugin_authorize(request, plugin_name):
         return HttpResponseBadRequest(f"Parameter 'type' must be '{AuthType.APP_INSTALL}' or '{AuthType.USER_LOGIN}'")
 
     if type == AuthType.APP_INSTALL and not community:
+        #FIXME make this optional, create new comm if not provided.
         return HttpResponseBadRequest("Missing 'community'")
 
     if community is not None:

--- a/metagov/metagov/core/views.py
+++ b/metagov/metagov/core/views.py
@@ -198,7 +198,7 @@ def plugin_authorize(request, plugin_name):
             community = Community.objects.create()
             # TODO: delete the community if installation fails.
             logger.debug(f"Created new community for installing {plugin_name}: {community}")
-        community_slug = community.slug
+        community_slug = str(community.slug)
 
     # Create the state
     nonce = utils.generate_nonce()

--- a/metagov/metagov/plugins/slack/views.py
+++ b/metagov/metagov/plugins/slack/views.py
@@ -25,18 +25,18 @@ REQUIRE_INSTALLER_TO_BE_ADMIN = True
 
 
 class NonAdminInstallError(PluginAuthError):
-    default_code = "user_is_not_admin"
+    default_code = "slack_installer_is_not_admin"
     default_detail = "Non-admin user is not permitted to install"
 
 
 class AlreadyInstalledError(PluginAuthError):
-    default_code = "already_installed"
+    default_code = "slack_already_installed"
     default_detail = "This community already has Slack enabled, but for a different workspace. Only one Slack workspace is permitted per community."
 
 
 class WrongCommunityError(PluginAuthError):
-    default_code = "wrong_community"
-    default_detail = "Already isntalled to this Slack workspace for a different community. Uninstall and try again."
+    default_code = "slack_wrong_community"
+    default_detail = "Already installed to this Slack workspace for a different community. Uninstall and try again."
 
 
 def get_authorize_url(state, type, community=None):


### PR DESCRIPTION
* Make `community` optional on the `/authorize` endpoint. If not provided, create a new community to enable the plugin for.
* Add a bunch of comments to the Slack auth functions to explain whats going on. There will probably be repetition with code grant oauth flows for GitHub/Discord and others, I'm sure we can pull some things out to core. @shaunagm 

**If using PolicyKit, MUST be deployed with a commit at or after https://github.com/amyxzhang/policykit/pull/444 **