### PR TITLE
Update Loomio vote outcome shape to match Slack/OC/GitHub vote processes

### DIFF
--- a/metagov/metagov/plugins/loomio/models.py
+++ b/metagov/metagov/plugins/loomio/models.py
@@ -188,4 +188,7 @@ class LoomioPoll(GovernanceProcess):
 
 def create_vote_dict(response):
     poll_options = response["poll_options"]
-    return {opt["name"]: opt["total_score"] for opt in poll_options}
+    result = {}
+    for opt in poll_options:
+        result[opt["name"]] = {"count": opt["total_score"], "users": list(opt["voter_scores"].keys())}
+    return result

--- a/metagov/metagov/plugins/loomio/tests/test_loomio.py
+++ b/metagov/metagov/plugins/loomio/tests/test_loomio.py
@@ -3,8 +3,9 @@ from django.test import TestCase
 import metagov.plugins.loomio.tests.mocks as LoomioMock
 
 
-
 class UnitTests(TestCase):
     def test_vote_dict(self):
         vote_dict = create_vote_dict(LoomioMock.loomio_show_poll_response)
-        self.assertDictEqual(vote_dict, {"agree": 1, "disagree": 0})
+        self.assertDictEqual(
+            vote_dict, {"agree": {"count": 1, "users": ["879750"]}, "disagree": {"count": 0, "users": []}}
+        )


### PR DESCRIPTION
Include list of Loomio user IDs as strings in the LoomioPoll outcome object. The shape matches across voting processes for GitHub, Open Collective, and Slack. 